### PR TITLE
ci: harden workflows and add Trivy image scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/docker"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore(update)"
+
+  - package-ecosystem: "github-actions"
+    # Applies to all workflow files under .github/workflows/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(update)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ on:
   workflow_dispatch:
   
 permissions:
-  packages: write
-  contents: write
+  packages: read
+  contents: read
 
 # https://docs.github.com/en/actions/using-jobs/using-concurrency
 concurrency:
@@ -68,6 +68,9 @@ defaults:
 jobs:
   superset-docker:
     name: build-${{ matrix.image }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -80,6 +83,8 @@ jobs:
 
   helm-lint:
     name: helm-lint
+    permissions:
+      contents: write
     uses: ./.github/workflows/helm-lint-template.yml
     needs: [superset-docker]
 

--- a/.github/workflows/docker-build-test-push-template.yml
+++ b/.github/workflows/docker-build-test-push-template.yml
@@ -58,7 +58,7 @@ jobs:
 
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
 #      - name: Free up disk space 📦
 #        uses: okdp/gh-workflows/.github/actions/free-disk-space@v1
@@ -97,25 +97,30 @@ jobs:
 
       - name: Set CI image tag
         id: image-tag
+        env:
+          BRANCH: ${{ steps.get-branch.outputs.branch }}
+          REGISTRY_REPO: ${{ steps.ci_registry.outputs.registry_repo }}
+          IMAGE: ${{ inputs.image }}
+          ADD_TAG_SUFFIX: ${{ inputs.add-tag-suffix }}
         run: |
-          branch="${{ steps.get-branch.outputs.branch }}"
+          branch="${BRANCH}"
           tag_branch="${branch//\//--}"
-          ci_tag="${{ steps.ci_registry.outputs.registry_repo }}/${{ inputs.image }}:${tag_branch}${{ inputs.add-tag-suffix }}"
+          ci_tag="${REGISTRY_REPO}/${IMAGE}:${tag_branch}${ADD_TAG_SUFFIX}"
 
           echo "ci_tag=$ci_tag" >> "$GITHUB_OUTPUT"
           echo "ci_tag=$ci_tag" >> "$GITHUB_ENV"
-            echo "Set image tag to: $ci_tag"
+          echo "Set image tag to: $ci_tag"
 
       - name: Login into ${{ steps.ci_registry.outputs.ci_registry }} registry 🔐
         if: steps.push-policy.outputs.can_push_ci == 'true'
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ steps.ci_registry.outputs.ci_registry }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image ${{ steps.image-tag.outputs.ci_tag }} 📤
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}

--- a/.github/workflows/docker-publish-template.yml
+++ b/.github/workflows/docker-publish-template.yml
@@ -45,6 +45,9 @@ on:
         type: string
         default: ""
 
+permissions:
+  contents: read
+
 defaults:
   run:
     shell: bash
@@ -58,7 +61,7 @@ jobs:
       latest_git_tag: ${{ steps.latest-image-tag.outputs.latest_git_tag }}
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Get latest GitHub Release tag name 📥
         id: latest-image-tag
@@ -70,7 +73,7 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout release tag ${{ needs.latest-image-tag.outputs.latest_git_tag }} ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           ref: ${{ needs.latest-image-tag.outputs.latest_git_tag }}
@@ -91,7 +94,7 @@ jobs:
       ### Publish steps
       ### The publish and periodic rebuilds are based on the latest stable github release tag
       - name: Login into ${{ steps.registry.outputs.registry }} registry 🔐
-        uses: docker/login-action@v4
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
           registry: ${{ steps.registry.outputs.registry }}
           username: ${{ secrets.REGISTRY_USERNAME }}
@@ -99,20 +102,25 @@ jobs:
 
       - name: Set image tags
         id: image-tags
+        env:
+          LATEST_TAG: ${{ needs.latest-image-tag.outputs.latest_tag }}
+          REGISTRY_REPO: ${{ steps.registry.outputs.registry_repo }}
+          IMAGE: ${{ inputs.image }}
+          ADD_TAG_SUFFIX: ${{ inputs.add-tag-suffix }}
         run: |
-           IMAGE_TAG=$(echo "${{ needs.latest-image-tag.outputs.latest_tag }}" | awk -F- '{ print $1 }')
-           if [ "$IMAGE_TAG" != "${{ needs.latest-image-tag.outputs.latest_tag }}" ]
+           IMAGE_TAG=$(echo "$LATEST_TAG" | awk -F- '{ print $1 }')
+           if [ "$IMAGE_TAG" != "$LATEST_TAG" ]
            then
-             IMAGE_TAGS="${{ steps.registry.outputs.registry_repo }}/${{ inputs.image }}:${IMAGE_TAG}${{ inputs.add-tag-suffix }},"
+             IMAGE_TAGS="${REGISTRY_REPO}/${IMAGE}:${IMAGE_TAG}${ADD_TAG_SUFFIX},"
            fi
 
-           IMAGE_TAGS+="${{ steps.registry.outputs.registry_repo }}/${{ inputs.image }}:${{ needs.latest-image-tag.outputs.latest_tag }}${{ inputs.add-tag-suffix }}"
+           IMAGE_TAGS+="${REGISTRY_REPO}/${IMAGE}:${LATEST_TAG}${ADD_TAG_SUFFIX}"
            
            echo "tags=${IMAGE_TAGS}" >> $GITHUB_OUTPUT
            echo "Set image tags to: $IMAGE_TAGS"
 
       - name: Build and push to ${{ steps.registry.outputs.registry_repo }} repository 📤
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: ${{ inputs.context }}
           file: ${{ inputs.dockerfile }}
@@ -125,4 +133,3 @@ jobs:
             org.opencontainers.image.description="${{ inputs.image }} image"
             org.opencontainers.image.source="https://github.com/${{ github.repository }}"
             org.opencontainers.image.licenses="Apache-2.0"
-

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -39,6 +39,7 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
+  contents: read
   packages: write
   
 jobs:

--- a/.github/workflows/helm-lint-template.yml
+++ b/.github/workflows/helm-lint-template.yml
@@ -35,6 +35,9 @@ on:
         type: string
         default: "ghcr.io"
 
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: bash
@@ -45,21 +48,21 @@ jobs:
     runs-on: "ubuntu-latest"
     steps:
       - name: Checkout Repo ⚡️
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
       
       - name: Setup helm
-        uses: azure/setup-helm@v4.2.0
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4.3.0
         with:
           version: v3.15.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: '3.10'
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.6.1
+        uses: helm/chart-testing-action@e6669bcd63d7cb57cb4380c33043eebe5d111992 # v2.6.1
   
       - name: Run chart-testing (list-changed) ✅
         id: list-changed
@@ -93,18 +96,26 @@ jobs:
 
       - name: Set CI Repo and image tag
         if: steps.list-changed.outputs.changed == 'true' && inputs.skip_chart_test != 'true'
+        env:
+          BRANCH: ${{ steps.get-branch.outputs.branch }}
+          CI_REGISTRY: ${{ vars.CI_REGISTRY || inputs.ci_registry }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          echo "CI_TAG=${{ steps.get-branch.outputs.branch }}" >> $GITHUB_ENV
-          echo "REGISTRY_REPO=${{ vars.CI_REGISTRY || inputs.ci_registry }}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_ENV
+          echo "CI_TAG=$BRANCH" >> $GITHUB_ENV
+          echo "REGISTRY_REPO=$CI_REGISTRY/${REPO_OWNER@L}" >> $GITHUB_ENV
 
       - name: Create CI registry secret 🔐
         if: steps.list-changed.outputs.changed == 'true' && inputs.skip_chart_test != 'true'
+        env:
+          CI_REGISTRY: ${{ inputs.ci_registry }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           kubectl create secret docker-registry ci-registry-secret \
-            --docker-server=${{ inputs.ci_registry }} \
-            --docker-username="${{ github.actor }}" \
-            --docker-password="${{ secrets.GITHUB_TOKEN }}" \
-            --docker-email="${{ github.actor }}@users.noreply.github.com" \
+            --docker-server="$CI_REGISTRY" \
+            --docker-username="$GITHUB_ACTOR" \
+            --docker-password="$GITHUB_TOKEN" \
+            --docker-email="$GITHUB_ACTOR@users.noreply.github.com" \
             -n default
 
       - name: Patch default service account with imagePullSecret 🧩
@@ -118,6 +129,8 @@ jobs:
 
       - name: Run chart-testing (install) ✅
         if: steps.list-changed.outputs.changed == 'true' && inputs.skip_chart_test != 'true'
+        env:
+          IMAGE: ${{ inputs.image }}
         run: |
           kubectl get events -A -w &
           (while true; do
@@ -126,11 +139,11 @@ jobs:
           sleep 15
           done) &
           ct install --config .ct.yml --namespace default \
-             --helm-extra-set-args "--set=superset.image.repository=$REGISTRY_REPO/${{ inputs.image }} \
+             --helm-extra-set-args "--set=superset.image.repository=$REGISTRY_REPO/$IMAGE \
                   --set=superset.image.tag=${CI_TAG} \
-                  --set=superset.initImage.repository=$REGISTRY_REPO/${{ inputs.image }} \
+                  --set=superset.initImage.repository=$REGISTRY_REPO/$IMAGE \
                   --set=superset.initImage.tag=${CI_TAG}-dockerize \
-                  --set=superset.supersetWebsockets.image.repository=$REGISTRY_REPO/${{ inputs.image }} \
+                  --set=superset.supersetWebsockets.image.repository=$REGISTRY_REPO/$IMAGE \
                   --set=superset.supersetWebsockets.image.tag=${CI_TAG}-websocket" \
              --print-config
 
@@ -148,11 +161,10 @@ jobs:
         if: |
             ${{ ((github.event_name == 'push') || (github.event_name == 'pull_request'
                   && github.event.pull_request.head.repo.full_name == github.repository)) }}
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
         with:
           pull: "--rebase --autostash"
           add: "**/README.md"
           message: '[helm-docs] Update readme'
           author_name: github-actions[bot]
           author_email: 41898282+github-actions[bot]@users.noreply.github.com
-

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,7 +48,7 @@ jobs:
     # The pull request should come from the same repo (github_token from the fork does not have write permissions)
     if: github.repository_owner == 'OKDP' && github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@7987652d64b4581673a76e33ad5e98e3dd56832f # v4.1.3
         id: release-please
 
   docker-publish:
@@ -76,4 +76,3 @@ jobs:
       version: ${{ needs.release-please.outputs.helm-version }}
       git_tag_name: ${{ needs.release-please.outputs.helm-tag_name }}
     secrets: inherit
-

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,103 @@
+#
+# Copyright 2026 The OKDP Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: trivy-scan
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - docker-rebuild
+      - release-please
+    types:
+      - completed
+    branches:
+      - main
+
+  schedule:
+    - cron: '0 12 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  latest-image-tag:
+    if: >-
+      github.repository_owner == 'OKDP' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'schedule' ||
+        github.event.workflow_run.conclusion == 'success'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      latest_tag: ${{ steps.latest-image-tag.outputs.latest_tag }}
+      base_tag: ${{ steps.image-tags.outputs.base_tag }}
+    steps:
+      - name: Checkout Repo ⚡️
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Get latest GitHub Release tag name 📥
+        id: latest-image-tag
+        uses: okdp/gh-workflows/.github/actions/latest-image-tag@8d94358b6324815c1bb0dab94f5d56a2784fa981 # v1
+
+      - name: Get image tags
+        id: image-tags
+        env:
+          LATEST_TAG: ${{ steps.latest-image-tag.outputs.latest_tag }}
+        run: |
+          echo "base_tag=${LATEST_TAG%%-*}" >> "$GITHUB_OUTPUT"
+
+  trivy-scan:
+    needs: [latest-image-tag]
+    name: scan-${{ matrix.image }}:${{ matrix.tag == 'base' && needs.latest-image-tag.outputs.base_tag || needs.latest-image-tag.outputs.latest_tag }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image: ['superset', 'dockerize', 'websocket']
+        tag: ['base', 'latest']
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout Repo ⚡️
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up container registry 📦
+        id: registry
+        env:
+          REGISTRY: ${{ vars.REGISTRY || 'quay.io' }}
+        run: |
+          echo "registry_repo=${REGISTRY}/${GITHUB_REPOSITORY_OWNER@L}" >> $GITHUB_OUTPUT
+
+      - name: Run Trivy vulnerability scanner 🔎
+        if: matrix.tag == 'latest' || needs.latest-image-tag.outputs.base_tag != needs.latest-image-tag.outputs.latest_tag
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
+        with:
+          image-ref: ${{ steps.registry.outputs.registry_repo }}/superset:${{ matrix.tag == 'base' && needs.latest-image-tag.outputs.base_tag || needs.latest-image-tag.outputs.latest_tag }}${{ matrix.image != 'superset' && format('-{0}', matrix.image) || '' }}
+          format: 'sarif'
+          output: 'trivy-results-${{ matrix.image }}-${{ matrix.tag }}.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy scan results to GitHub Security tab 📤
+        uses: github/codeql-action/upload-sarif@b6a472f63d85b9c78a3ac5e89422239fc15e9b3c # v3.28.1
+        if: always() && (matrix.tag == 'latest' || needs.latest-image-tag.outputs.base_tag != needs.latest-image-tag.outputs.latest_tag)
+        with:
+          sarif_file: 'trivy-results-${{ matrix.image }}-${{ matrix.tag }}.sarif'
+          category: trivy-superset-${{ matrix.tag == 'base' && needs.latest-image-tag.outputs.base_tag || needs.latest-image-tag.outputs.latest_tag }}${{ matrix.image != 'superset' && format('-{0}', matrix.image) || '' }}


### PR DESCRIPTION
## Description

This PR hardens the GitHub Actions workflows and adds security automation for published Superset container images.

Changes include:

* harden workflow permissions by explicitly setting the required `GITHUB_TOKEN` scopes
* fix permissions inheritance for reusable workflows
* pin third-party GitHub Actions to commit SHAs for supply-chain security
* add a scheduled Trivy workflow to scan published Superset images
* allow the Trivy scan to run manually with `workflow_dispatch`
* trigger the Trivy scan after successful `docker-rebuild` and `release-please` workflow completions
* scan the published Superset image variants:

  * `superset`
  * `superset:<version>-dockerize`
  * `superset:<version>-websocket`
* scan both the base image tag and the full release tag when they differ, for example:

  * `quay.io/okdp/superset:6.0.0`
  * `quay.io/okdp/superset:6.0.0-1.0`
* add Dependabot configuration for Docker and GitHub Actions updates

The goal is to improve CI/CD security, keep workflow dependencies up to date, and continuously scan published images for critical and high vulnerabilities.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [x] Refactor / chore
* [ ] Breaking change

## How to Test

1. Verify that workflow files pass GitHub Actions syntax validation.
2. Run the Trivy workflow manually from the GitHub Actions UI.
3. Confirm that the workflow resolves the latest non-Helm release tag.
4. Confirm that Trivy scans the expected published image tags, including base and release-suffixed tags when applicable.
5. Confirm that Trivy uploads SARIF results to GitHub Code Scanning.
6. Confirm that reusable workflows still run with the expected permissions.
7. Confirm that Dependabot detects Docker and GitHub Actions updates from `.github/dependabot.yml`.

## Checklist

* [x] I have tested my changes
* [x] Documentation updated if needed
* [x] If breaking change: migration path described above
* [x] I hereby declare this contribution to be licensed under the [[Apache License Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)](http://www.apache.org/licenses/LICENSE-2.0).
* [x] I hereby agree to grant [[TOSIT](https://www.tosit.io/)](https://www.tosit.io/) a copyright license to use my contributions.